### PR TITLE
Add explicit imports instead of wildcards

### DIFF
--- a/ipygee/map.py
+++ b/ipygee/map.py
@@ -1,24 +1,25 @@
 # coding=utf-8
 
 """ Display an interactive Map for Google Earth Engine using ipyleaflet """
+import re
+import sys
+import traceback
+from collections import OrderedDict
+from copy import copy
 
 import ee
 import ipyleaflet
-from ipywidgets import Layout, HTML, Accordion
-from traitlets import *
-from collections import OrderedDict
-from .tasks import TaskManager
-from .assets import AssetManager
 from geetools import tools, utils
 from IPython.display import display
-from .tabs.layers import LayersWidget
-from copy import copy
-import traceback
-from .maptools import *
-from .widgets import ErrorAccordion
-from .utils import *
-import re
+from ipywidgets import HTML, Accordion, Layout
+from traitlets import Dict, observe
 
+from .assets import AssetManager
+from .maptools import *
+from .tabs.layers import LayersWidget
+from .tasks import TaskManager
+from .utils import *
+from .widgets import ErrorAccordion
 
 ZOOM_SCALES = {
     0: 156543, 1: 78271, 2: 39135, 3: 19567, 4: 9783, 5: 4891, 6: 2445,

--- a/ipygee/tabs/layers.py
+++ b/ipygee/tabs/layers.py
@@ -1,11 +1,11 @@
 # coding=utf-8
 
 """ Layers widget for Map tab """
-
+import ee
 from ..widgets import RealBox
 from ipywidgets import *
 from ..threading import Thread
-from traitlets import *
+from traitlets import Float
 from .. import utils
 
 

--- a/ipygee/widgets.py
+++ b/ipygee/widgets.py
@@ -3,8 +3,7 @@
 """ Generic Custom Widgets to use in this module """
 
 from ipywidgets import *
-from traitlets import *
-
+from traitlets import Instance, observe, List, Int, Unicode
 
 class CheckRow(HBox):
     checkbox = Instance(Checkbox)


### PR DESCRIPTION
Some wildcards import were failing on recent versions of traitless.

This PR adds explicit import in places where objects from traitless were used.

